### PR TITLE
save participants list and invite people from the list on game start

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -50,8 +50,8 @@ def invite_participants(bot, participants_input: str):
                              reply_markup=telegram.ReplyKeyboardRemove())
 
 
-def save_participants(participants_input: str):
-    with open(participants_input, 'wb') as fo:
+def save_participants(participants_output: str):
+    with open(participants_output, 'wb') as fo:
         pickle.dump([participant.id for participant in GAME_STATE.get_all()], fo)
 
 


### PR DESCRIPTION
1. option -o allows to save a list of all participants on game end
2. option -o allows to load the previously saved list on game start and to invite all previous participants to the game

why bother? because it's annoying to type in "/start" every time. Now, the bot will provide the "/start" button to the participants automatically